### PR TITLE
Various amendments for last Grafana release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ grafana_log_dir:      /var/log/grafana
 grafana_home_dir:     /usr/share/grafana
 grafana_data_dir:     /var/lib/grafana
 grafana_conf_dir:     /etc/grafana
+grafana_pid_dir:      /run/grafana
 grafana_plugins_dir:  "{{ grafana_data_dir }}/plugins"       # consider removing this since it is under data_dir
 grafana_conf_file:    "{{ grafana_conf_dir }}/grafana.ini"   # consider removing this since it is under conf_dir
 

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -22,6 +22,14 @@
     group: root
     mode:  0644
 
+- name: import rpm keys
+  rpm_key: state=present key={{ item }}
+  with_items:
+    - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
+
+- name: update repo cache for the new repo
+  command: yum -q makecache -y --disablerepo=* --enablerepo=grafana
+
 - name: Install grafana
   yum:
     name:  "grafana-{{ grafana_version|default('*') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Grafana Install
-  include: "install-{{ ansible_os_family|lower }}.yml"
+  include_tasks: "install-{{ ansible_os_family|lower }}.yml"
 
 - name: Create grafana config file
   template:
@@ -38,4 +38,6 @@
   service: name=grafana-server enabled=yes state=started
 
 - name: Grafana plugins
-  include: plugins.yml
+  import_tasks: plugins.yml
+  tags:
+    - grafana_install_plugins 

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,4 +1,10 @@
 ---
+- name: Create plugin directory
+  file:
+    state: directory
+    path: "{{ grafana_plugins_dir }}"
+    owner: "{{ grafana_user }}" 
+    group: "{{ grafana_group }}"
 
 - name: Get list of installed grafana plugins
   shell: >
@@ -22,21 +28,22 @@
 - name: Get versions of installed grafana plugins pre update
   shell: >
       grafana-cli plugins ls | grep '@'
+  when: plugins.stdout_lines|count > 0
   register: versions_pre_update
 
 - name: Update grafana plugins
   shell: >
       grafana-cli plugins update-all
-  when: grafana_update_plugins
+  when: grafana_update_plugins and plugins.stdout_lines|count > 0
   ignore_errors: true
 
 - name: Get versions of installed grafana plugins post update
   shell: >
       grafana-cli plugins ls | grep '@'
-  when: grafana_update_plugins
+  when: grafana_update_plugins and plugins.stdout_lines|count > 0
   register: versions_post_update
 
 - name: Trigger grafana restart if grafana plugins updated
   set_fact: restart_grafana=true
-  when: versions_pre_update.stdout != versions_post_update.stdout
+  when: plugins.stdout_lines|count > 0 and versions_pre_update.stdout != versions_post_update.stdout
   notify: Restart grafana

--- a/templates/etc.default.grafana-server.j2
+++ b/templates/etc.default.grafana-server.j2
@@ -17,3 +17,5 @@ CONF_FILE={{ grafana_conf_dir }}/grafana.ini
 RESTART_ON_UPGRADE={{ grafana_restart_on_upgrade|default(false)|bool|lower }}
 
 PLUGINS_DIR={{ grafana_data_dir }}/plugins
+
+PID_FILE_DIR={{ grafana_pid_dir }}

--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -52,8 +52,8 @@ static_root_path = {{ grafana_server_static_root_path }}
 enable_gzip = {{ grafana_server_enable_gzip|default(false)|bool|lower }}
 
 # https certs & key file
-cert_file = {{ grafana_cert_file|default('') }}
-cert_key = {{ grafana_cert_key|default('') }}
+cert_file = {{ grafana_server_cert_file|default('') }}
+cert_key = {{ grafana_server_cert_key|default('') }}
 
 #################################### Database ####################################
 [database]


### PR DESCRIPTION
Fix variable names in grafana.ini, make the plugins section work when no plugins are installed, create missing plugins directory, use last include_tasks/import_tasks statement, import GPG key and refresh yum cache to avoid interactive mode when installing the package