### PR TITLE
Restart Grafana server if Grafana version is updated

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -15,3 +15,4 @@
   apt:
     name:  "grafana={{ grafana_version|default('*') }}"
     state: present
+  notify: Restart grafana

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -32,3 +32,4 @@
     name:  "grafana-{{ grafana_version|default('*') }}"
     update_cache: yes
     state: present
+  notify: Restart grafana


### PR DESCRIPTION
If you have a running Grafana server, it is not restarted if the version is updated.