### PR TITLE
Manage Grafana 6.X

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,6 @@
 grafana_user:  grafana
 grafana_group: "{{ grafana_user }}"
 
-
 #############
 ## Package
 grafana_version: '*'                # e.g. 6.0.0 or '*' for latest
@@ -291,7 +290,6 @@ grafana_log_syslog_address:
 grafana_log_syslog_facility:
 grafana_log_syslog_tag:
 
-
 #################################### Alerting ############################
 grafana_alerting_enabled: true
 grafana_alerting_execute_alerts: true
@@ -361,5 +359,3 @@ grafana_external_image_storage_panels_disable_sanitize_html: false
 # [plugins]
 grafana_external_image_storage_plugins_enable_alpha: false
 grafana_external_image_storage_plugins_app_tls_skip_verify_insecure: false
-
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -283,26 +283,80 @@ grafana_log_file_max_days:        7          # Expired days of log file(delete a
 ## [log.syslog]
 grafana_log_syslog_level:
 grafana_log_syslog_format: text
+grafana_log_syslog_network:
+grafana_log_syslog_address:
+grafana_log_syslog_facility:
+grafana_log_syslog_tag:
 
-#################################### AMPQ Event Publisher ##########################
-grafana_event_publisher_enabled:        false
-grafana_event_publisher_rabbitmq_url:   "amqp://localhost/"
-grafana_event_publisher_exchange:       grafana_events
 
-#################################### Dashboard JSON files ##########################
-grafana_dashboards_json_enabled:   false
-grafana_dashboards_json_path:      "{{ grafana_data_dir }}/dashboards"
+#################################### Alerting ############################
+grafana_alerting_enabled: true
+grafana_alerting_execute_alerts: true
+grafana_alerting_error_or_timeout: alerting
+grafana_alerting_nodata_or_nullvalues: no_data
+grafana_alerting_concurrent_render_limit: 5
+grafana_alerting_evaluation_timeout_seconds: 30
+grafana_alerting_notification_timeout_seconds: 30
+grafana_alerting_max_attempts: 3
 
-#################################### Usage Quotas ##########################
-grafana_quota_enabled: false
-#### set quotas to -1 to make unlimited. ####
-grafana_quota_org_user:           10     # limit number of users per Org.
-grafana_quota_org_dashboard:      100    # limit number of dashboards per Org.
-grafana_quota_org_data_source:    10     # limit number of data_sources per Org.
-grafana_quota_org_api_key:        10     # limit number of api_keys per Org.
-grafana_quota_user_org:           10     # limit number of orgs a user can create.
-grafana_quota_global_user:        -1     # Global limit of users.
-grafana_quota_global_org:         -1     # global limit of orgs.
-grafana_quota_global_dashboard:   -1     # global limit of dashboards
-grafana_quota_global_api_key:     -1     # global limit of api_keys
-grafana_quota_global_session:     -1     # global limit on number of logged in users.
+#################################### Explore #############################
+grafana_explore_enabled: true
+
+#################################### Internal Grafana Metrics ##########################
+grafana_metrics_enabled: true
+grafana_metrics_interval_seconds: 10
+grafana_metrics_graphite_address:
+grafana_metrics_graphite_prefix: "prod.grafana.%(instance_name)s."
+
+#################################### Distributed tracing ############
+grafana_tracing_jaeger_address: "localhost:6831"
+grafana_tracing_jaeger_always_included_tag: "tag1:value1"
+grafana_tracing_jaeger_sampler_type: const
+grafana_tracing_jaeger_sampler_param: 1
+
+#################################### Grafana.com integration  ##########################
+grafana_dashboard_import_url: https://grafana.com
+
+#################################### External image storage ##########################
+# Used for uploading images to public servers so they can be included in slack/email messages.
+# you can choose between (s3, webdav, gcs, azure_blob, local)
+grafana_external_image_storage_provider:
+
+# [external_image_storage.s3]
+grafana_external_image_storage_s3_bucket:
+grafana_external_image_storage_s3_region:
+grafana_external_image_storage_s3_path:
+grafana_external_image_storage_s3_access_key:
+grafana_external_image_storage_s3_secret_key:
+
+# [external_image_storage.webdav]
+grafana_external_image_storage_webdav_url:
+grafana_external_image_storage_webdav_public_url:
+grafana_external_image_storage_webdav_username:
+grafana_external_image_storage_webdav_password:
+
+# [external_image_storage.gcs]
+grafana_external_image_storage_gcs_key_file:
+grafana_external_image_storage_gcs_bucket:
+grafana_external_image_storage_gcs_path:
+
+# [external_image_storage.azure_blob]
+grafana_external_image_storage_azure_blob_account_name:
+grafana_external_image_storage_azure_blob_account_key:
+grafana_external_image_storage_azure_blob_container_name:
+
+# [rendering]
+grafana_external_image_storage_rendering_server_url:
+grafana_external_image_storage_rendering_callback_url:
+
+# [enterprise]
+grafana_external_image_storage_enterprise_license_path:
+
+# [panels]
+grafana_external_image_storage_panels_disable_sanitize_html: false
+
+# [plugins]
+grafana_external_image_storage_plugins_enable_alpha: false
+grafana_external_image_storage_plugins_app_tls_skip_verify_insecure: false
+
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -206,15 +206,18 @@ grafana_auth_ldap_config_file:  "{{ grafana_conf_dir }}/ldap.toml"
 grafana_auth_ldap_allow_sign_up:
 
 ###### ldap.toml #######
-grafana_ldap_verbose_logging: false    # Set to true to log user information returned from LDAP
+grafana_ldap_log_enabled: false
 
 ##  [[servers]]
 grafana_ldap_servers_host:            "127.0.0.1" # Ldap server host (specify multiple hosts space separated)
 grafana_ldap_servers_port:            389         # Default port is 389 or 636 if use_ssl = true
 grafana_ldap_servers_use_ssl:         false       # Set to true if ldap server supports TLS
+grafana_ldap_servers_start_tls:       false
 grafana_ldap_servers_ssl_skip_verify: false       # set to true if you want to skip ssl cert validation
 grafana_ldap_servers_root_ca_cert:                # set to the path to your root CA certificate or leave unset to use system defaults
                                                   # root_ca_cert = /path/to/certificate.crt
+grafana_ldap_servers_client_cert:
+grafana_ldap_servers_client_key:
 
 grafana_ldap_servers_bind_dn: "cn=admin,dc=grafana,dc=org"  # Search user bind dn
 grafana_ldap_servers_bind_password: 'grafana'               # Search user bind password

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,11 +5,10 @@ grafana_group: "{{ grafana_user }}"
 
 #############
 ## Package
-grafana_version: '*'                # e.g. 3.0.4 or '*' for latest
-grafana_signing_key_url: "https://packagecloud.io/gpg.key"
-grafana_apt_repo: "deb https://packagecloud.io/grafana/stable/debian/ wheezy main"
-grafana_yum_signing_key_url: "https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana"
-grafana_yum_repo_baseurl: 'https://packagecloud.io/grafana/stable/el/6/$basearch'
+grafana_version: '*'                # e.g. 6.0.0 or '*' for latest
+grafana_signing_key_url: "https://packages.grafana.com/gpg.key"
+grafana_apt_repo: "deb https://packages.grafana.com/oss/deb stable main"
+grafana_yum_repo_baseurl: 'https://packages.grafana.com/oss/rpm'
 
 grafana_plugins_install: []
 grafana_plugins_remove:  []
@@ -18,6 +17,8 @@ grafana_update_plugins:  true
 #################
 ## Configuration
 
+grafana_instance_name: "${HOSTNAME}"
+grafana_temp_data_lifetime: "24h"
 grafana_log_dir:      /var/log/grafana
 grafana_home_dir:     /usr/share/grafana
 grafana_data_dir:     /var/lib/grafana
@@ -25,6 +26,7 @@ grafana_conf_dir:     /etc/grafana
 grafana_pid_dir:      /run/grafana
 grafana_plugins_dir:  "{{ grafana_data_dir }}/plugins"       # consider removing this since it is under data_dir
 grafana_conf_file:    "{{ grafana_conf_dir }}/grafana.ini"   # consider removing this since it is under conf_dir
+grafana_provisioning_dir: "conf/provisioning"
 
 grafana_max_open_files: 10000
 grafana_restart_on_upgrade: false
@@ -49,6 +51,7 @@ grafana_database_host: "127.0.0.1:3306"
 grafana_database_name: grafana
 grafana_database_user: root
 grafana_database_password:
+
 # For "postgres" only, either "disable", "require" or "verify-full"
 grafana_database_ssl_mode: disable
 # For "sqlite3" only, path relative to data_path setting
@@ -60,13 +63,20 @@ grafana_database_client_key_path:
 grafana_database_client_cert_path:
 grafana_database_server_cert_name:
 
-#################################### Session ####################################
-grafana_session_provider:           file            # Either "memory", "file", "redis", "mysql", "postgres", default is "file"
-grafana_session_provider_config:    sessions
-grafana_session_cookie_name:        grafana_sess    # Session cookie name
-grafana_session_cookie_secure:      false           # If you use session in https only, default is false
-grafana_session_session_life_time:  86400           # Session life time, default is 86400
-grafana_session_gc_interval_time:   86400
+grafana_database_max_idle_conn: 2
+grafana_database_max_open_conn:
+grafana_database_conn_max_lifetime: 14400
+grafana_database_log_queries:
+grafana_database_cache_mode: private
+
+#################################### Cache Server ###############################
+grafana_cache_server_type: database
+grafana_cache_server_connection_string:
+
+#################################### Data Proxy #################################
+grafana_data_proxy_logging: false
+grafana_data_proxy_timeout: 30
+grafana_data_proxy_send_user_header: false
 
 #################################### Analytics ####################################
 grafana_analytics_reporting_enabled: true   # Server reporting, sends usage counters to stats.grafana.org every 24 hours.
@@ -80,17 +90,23 @@ grafana_security_admin_user: admin                    # default admin user, crea
 grafana_security_admin_password: admin                # default admin password, can be changed before first start of grafana,  or in profile settings
 grafana_security_secret_key: SW2YcwTIb9zpOOhoPsMm     # used for signing
 # Auto-login remember days
-grafana_security_login_remember_days: 7
-grafana_security_cookie_username: grafana_user
-grafana_security_cookie_remember_name: grafana_remember
 grafana_security_disable_gravatar: false              # disable gravatar profile images
 grafana_security_data_source_proxy_whitelist:         # data source proxy whitelist (ip_or_domain:port seperated by spaces)
+grafana_security_disable_brute_force_login_protection: false
+grafana_security_cookie_secure: false
+grafana_security_cookie_samesite: lax
+grafana_security_allow_embedding: false
 
 ################################# Snapshots ####################################
 # snapshot sharing options
 grafana_snapshots_external_enabled:       true
 grafana_snapshots_external_snapshot_url:  "https://snapshots-origin.raintank.io"
 grafana_snapshots_external_snapshot_name: "Publish to snapshot.raintank.io"
+grafana_snapshots_remove_expired: true
+
+################################# Dashboards History ##########################
+grafana_dashboard_history_versions_to_keep: 20
+
 
 #################################### Users ####################################
 grafana_users_allow_sign_up:        true      # disable user signup / registration
@@ -99,6 +115,23 @@ grafana_users_auto_assign_org:      true      # Set to true to automatically ass
 grafana_users_auto_assign_org_role: Viewer    # Default role new users will be automatically assigned (if disabled above is set to true)
 grafana_users_verify_email_enabled: false     # Require email validation before sign up completes
 grafana_users_login_hint:           'email or username'   # Background text for the user field on the login page
+grafana_users_password_hint: password
+grafana_users_default_theme: dark
+grafana_users_external_manage_link_urk:
+grafana_users_external_manage_link_name:
+grafana_users_external_manage_info:
+grafana_users_viewers_can_edit: false
+grafana_users_editors_can_admin: false
+
+# Auth
+grafana_users_auth_login_cookie_name: grafana_session
+grafana_users_auth_login_maximum_inactive_lifetime_days: 7
+grafana_users_auth_login_maximum_lifetime_days: 30
+grafana_users_auth_token_rotation_interval_minutes: 10
+grafana_users_auth_disable_login_form: false
+grafana_users_auth_disable_signout_menu: false
+grafana_users_auth_signout_redirect_url:
+grafana_users_auth_oauth_auto_login: false
 
 #################################### Anonymous Auth ##########################
 grafana_auth_anonymous_enabled:   false       # enable anonymous access
@@ -129,11 +162,40 @@ grafana_auth_google_token_url:       "https://accounts.google.com/o/oauth2/token
 grafana_auth_google_api_url:         "https://www.googleapis.com/oauth2/v1/userinfo"
 grafana_auth_google_allowed_domains:
 
+#################################### Generic OAuth ##########################
+grafana_auth_oauth_enabled: false
+grafana_auth_oauth_name: OAuth
+grafana_auth_oauth_allow_sign_up: true
+grafana_auth_oauth_client_id: some_id
+grafana_auth_oauth_client_secret: some_secret
+grafana_auth_oauth_scopes: "user:email,read:org"
+grafana_auth_oauth_auth_url: "https://foo.bar/login/oauth/authorize"
+grafana_auth_oauth_token_url: "https://foo.bar/login/oauth/access_token"
+grafana_auth_oauth_api_url: "https://foo.bar/user"
+grafana_auth_oauth_team_ids:
+grafana_auth_oauth_allowed_organizations:
+grafana_auth_oauth_tls_skip_verify_insecure: false
+grafana_auth_oauth_tls_client_cert:
+grafana_auth_oauth_tls_client_key:
+grafana_auth_oauth_tls_client_ca:
+grafana_auth_oauth_send_client_credentials_via_post: false
+
+#################################### Grafana.com Auth ####################
+grafana_auth_enabled: false
+grafana_auth_allow_sign_up: true
+grafana_auth_client_id: some_id
+grafana_auth_client_secret: some_secret
+grafana_auth_scopes: "user:email"
+grafana_auth_allowed_organizations:
+
 #################################### Auth Proxy ##########################
 grafana_auth_proxy_enabled:           false
 grafana_auth_proxy_header_name:       X-WEBAUTH-USER
 grafana_auth_proxy_header_property:   username
 grafana_auth_proxy_auto_sign_up:      true
+grafana_auth_proxy_ldap_sync_ttl: 60
+grafana_auth_proxy_whitelist: "192.168.1.1, 192.168.2.1"
+grafana_auth_proxy_headers: "Email:X-User-Email, Name:X-User-Name"
 
 #################################### Basic Auth ##########################
 grafana_auth_basic_enabled: true
@@ -141,7 +203,7 @@ grafana_auth_basic_enabled: true
 #################################### Auth LDAP ##########################
 grafana_auth_ldap_enabled:      false
 grafana_auth_ldap_config_file:  "{{ grafana_conf_dir }}/ldap.toml"
-
+grafana_auth_ldap_allow_sign_up:
 
 ###### ldap.toml #######
 grafana_ldap_verbose_logging: false    # Set to true to log user information returned from LDAP
@@ -192,6 +254,8 @@ grafana_smtp_cert_file:
 grafana_smtp_key_file:
 grafana_smtp_skip_verify:   false
 grafana_smtp_from_address:  admin@grafana.localhost
+grafana_smtp_from_name: Grafana
+grafana_smtp_ehlo_identity: dashboard.example.com
 
 ## [emails]
 grafana_emails_welcome_email_on_sign_up: false
@@ -199,20 +263,26 @@ grafana_emails_welcome_email_on_sign_up: false
 #################################### Logging ##########################
 # Either "console", "file", "syslog". Default is console and  file
 # Use comma to separate multiple modes, e.g. "console, file"
-grafana_log_mode:       'console, file'
-grafana_log_buffer_len: 10000           # Buffer length of channel, keep it as it is if you don't know what it is.
-grafana_log_level:      Info            # Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Info"
+grafana_log_mode: 'console, file'
+grafana_log_level: info # Either "debug", "info", "warn", "error", "critical", default is "info"
+grafana_log_filers:         
 
 ##  [log.console]
 grafana_log_console_level:
+grafana_log_console_format: console
 
 ##  [log.file]
 grafana_log_file_level:
+grafana_log_file_format: text
 grafana_log_file_log_rotate:      true      # This enables automated log rotate(switch of following options), default is true
 grafana_log_file_max_lines:       1000000   # Max line number of single file, default is 1000000
 grafana_log_file_max_lines_shift: 28        # Max size shift of single file, default is 28 means 1 << 28, 256MB
 grafana_log_file_daily_rotate:    true      # Segment log daily, default is true
 grafana_log_file_max_days:        7          # Expired days of log file(delete after max days), default is 7
+
+## [log.syslog]
+grafana_log_syslog_level:
+grafana_log_syslog_format: text
 
 #################################### AMPQ Event Publisher ##########################
 grafana_event_publisher_enabled:        false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
-  author: "Ogonna Iwunze"
+  author: "Ludovic Petetin"
+  description: Role to install a Grafana server
   company: None
   license: BSD
   min_ansible_version: 2.3
@@ -12,7 +13,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-  categories:
+  galaxy_tags:
     - grafana
     - monitoring
 dependencies: []

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -2,17 +2,13 @@
 
 - name: Download and install grafana apt public signing key
   apt_key:
-    url:   "{{ grafana_signing_key_url }}"
-    state: present
+    url: "{{ grafana_signing_key_url }}"
 
 - name: Add grafana apt repository definition to apt sources list
-  apt_repository: 
-    repo:         "{{ grafana_apt_repo }}"
-    update_cache: yes
-    state:        present
+  apt_repository:
+    repo: "{{ grafana_apt_repo }}"
 
 - name: Install grafana
   apt:
-    name:  "grafana={{ grafana_version|default('*') }}"
-    state: present
+    name: "grafana={{ grafana_version|default('*') }}"
   notify: Restart grafana

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -26,6 +26,8 @@
 - name: Update repo cache for grafana repo
   command: yum -q makecache -y --disablerepo=* --enablerepo=grafana
   when: import_key|changed
+  args:
+    warn: False
 
 - name: Install grafana
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,8 @@
   when: grafana_auth_ldap_enabled
   notify: Restart grafana
 
-- set_fact: _startup_env_vars_dir=/etc/sysconfig
+- name: Set a fact for startup environment vars directory
+  set_fact: _startup_env_vars_dir=/etc/sysconfig
   when: ansible_os_family|lower == 'redhat'
 
 - name: Update grafana startup script envrionment variables file

--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -6,21 +6,26 @@
 # possible values : production, development
 app_mode = production
 
+# instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
+instance_name = {{ grafana_instance_name }}
+
 #################################### Paths ####################################
 [paths]
 # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
-#
 data = {{ grafana_data_dir }}
-#
+
+# Temporary files in `data` directory older than given duration will be removed
+temp_data_lifetime = {{ grafana_temp_data_lifetime }}
+
 # Directory where grafana can store logs
-#
 logs = {{ grafana_log_dir }}
-#
+
 # Directory where grafana will automatically scan and look for plugins
-#
 plugins = {{ grafana_data_dir }}/plugins
 
-#
+# folder that contains provisioning config files that grafana will apply on startup and while running.
+provisioning = {{ grafana_provisioning_dir }}
+
 #################################### Server ####################################
 [server]
 # Protocol (http or https)
@@ -39,7 +44,8 @@ domain = {{ grafana_server_domain }}
 # Prevents DNS rebinding attacks
 enforce_domain = {{ grafana_server_enforce_domain|default(false)|bool|lower }}
 
-# The full public facing url
+# The full public facing url you use in browser, used for redirects and emails
+# If you use reverse proxy and sub path specify full url (with sub path)
 root_url = {{ grafana_server_root_url }}
 
 # Log web requests
@@ -55,17 +61,29 @@ enable_gzip = {{ grafana_server_enable_gzip|default(false)|bool|lower }}
 cert_file = {{ grafana_server_cert_file|default('') }}
 cert_key = {{ grafana_server_cert_key|default('') }}
 
+# Unix socket path
+socket = {{ grafana_server_unix_socket_path|default('') }}
+
 #################################### Database ####################################
 [database]
+# You can configure the database connection by specifying type, host, name, user and password
+# as separate properties or as on string using the url properties.
+
+{% if grafana_database_url is not defined %}
 # Either "mysql", "postgres" or "sqlite3", it's your choice
 type = {{ grafana_database_type|default('sqlite3') }}
 host = {{ grafana_database_host|default('127.0.0.1:3306') }}
 name = {{ grafana_database_name|default('grafana') }}
 user = {{ grafana_database_user|default('root') }}
+# If the password contains # or ; you have to wrap it with triple quotes. Ex """#password;"""
 password = {{ grafana_database_password|default('') }}
+{% else %}
+# Use either URL or the previous fields to configure the database
+# Example: mysql://user:secret@host:port/database
+url = {{ grafana_database_url|default('') }}
+{% endif %}
 
 # For "postgres", use either "disable", "require" or "verify-full"
-# For "mysql", use either "true", "false", or "skip-verify".
 ssl_mode = {{ grafana_database_ssl_mode|default('disable') }}
 
 {% if grafana_database_ssl_mode and grafana_database_ssl_mode != 'disable' and grafana_database_type == 'mysql' %}
@@ -82,32 +100,45 @@ server_cert_name = {{ grafana_database_server_cert_name|default('') }}
 path = {{ grafana_database_path|default('grafana.db') }}
 {% endif %}
 
-#################################### Session ####################################
-[session]
-# Either "memory", "file", "redis", "mysql", "postgres", "memcache", default is "file"
-provider = {{ grafana_session_provider }}
+# Max idle conn setting default is 2
+max_idle_conn = {{ grafana_database_max_idle_conn }}
 
-# Provider config options
-# memory: not have any config yet
-# file: session dir path, is relative to grafana data_path
+# Max conn setting default is 0 (mean not set)
+max_open_conn = {{ grafana_database_max_open_conn|default('') }}
+
+# Connection Max Lifetime default is 14400 (means 14400 seconds or 4 hours)
+conn_max_lifetime = {{ grafana_database_conn_max_lifetime }}
+
+# Set to true to log the sql calls and execution times.
+log_queries = {{ grafana_database_log_queries|default('') }}
+
+{% if grafana_database_type == 'sqlite3' %}
+# For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
+cache_mode = {{ grafana_database_cache_mode }}
+{% endif %}
+
+#################################### Cache server #############################
+[remote_cache]
+# Either "redis", "memcached" or "database" default is "database"
+type = {{ grafana_cache_server_type }}
+
+# cache connectionstring options
+# database: will use Grafana primary database.
 # redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
-# postgres: user=a password=b host=localhost port=5432 dbname=c sslmode=disable
-# mysql: go-sql-driver/mysql dsn config string, examples:
-#         `user:password@tcp(127.0.0.1:3306)/database_name`
-#         `user:password@unix(/var/run/mysqld/mysqld.sock)/database_name`
 # memcache: 127.0.0.1:11211
+connstr = {{ grafana_cache_server_connection_string|default('') }}
 
-provider_config = {{ grafana_session_provider_config }}
+#################################### Data proxy ###########################
+[dataproxy]
 
-# Session cookie name
-cookie_name = {{ grafana_session_cookie_name }}
+# This enables data proxy logging, default is false
+logging = {{ grafana_data_proxy_logging }}
 
-# If you use session in https only, default is false
-cookie_secure = {{ grafana_session_cookie_secure|default(false)|bool|lower }}
+# How long the data proxy should wait before timing out default is 30 (seconds)
+timeout = {{ grafana_data_proxy_timeout }}
 
-# Session life time, default is 86400
-session_life_time = {{ grafana_session_session_life_time|default(86400) }}
-gc_interval_time = {{ grafana_session_gc_interval_time|default(86400) }}
+# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
+send_user_header = {{ grafana_data_proxy_send_user_header }}
 
 #################################### Analytics ####################################
 [analytics]
@@ -141,22 +172,38 @@ admin_password = {{ grafana_security_admin_password|default('admin') }}
 # used for signing
 secret_key = {{ grafana_security_secret_key }}
 
-# Auto-login remember days
-login_remember_days = {{ grafana_security_login_remember_days|default(7) }}
-cookie_username = {{ grafana_security_cookie_username }}
-cookie_remember_name = {{ grafana_security_cookie_remember_name }}
-
 # disable gravatar profile images
-disable_gravatar = {{ grafana_security_disable_gravator|default(false)|bool|lower }}
+disable_gravatar = {{ grafana_security_disable_gravatar|default(false)|bool|lower }}
 
-# data source proxy whitelist (ip_or_domain:port seperated by spaces)
+# data source proxy whitelist (ip_or_domain:port separated by spaces)
 data_source_proxy_whitelist = {{ grafana_security_data_source_proxy_whitelist|default('') }}
 
+# disable protection against brute force login attempts
+disable_brute_force_login_protection = {{ grafana_security_disable_brute_force_login_protection|default(false)|bool|lower }}
+
+# set to true if you host Grafana behind HTTPS. default is false.
+cookie_secure = {{ grafana_security_cookie_secure }}
+
+# set cookie SameSite attribute. defaults to `lax`. can be set to "lax", "strict" and "none"
+cookie_samesite = {{ grafana_security_cookie_samesite }}
+
+# set to true if you want to allow browsers to render Grafana in a <frame>, <iframe>, <embed> or <object>. default is false.
+allow_embedding = {{ grafana_security_allow_embedding|default(false)|bool|lower }}
+
+#################################### Snapshots ###########################
 [snapshots]
 # snapshot sharing options
 external_enabled = {{ grafana_snapshots_external_enabled|default(true)|bool|lower }}
 external_snapshot_url = {{ grafana_snapshots_external_snapshot_url }}
 external_snapshot_name = {{ grafana_snapshots_external_snapshot_name }}
+
+# remove expired snapshot
+snapshot_remove_expired = {{ grafana_snapshots_remove_expired|default(true)|bool|lower }}
+
+#################################### Dashboards History ##################
+[dashboards]
+# Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
+versions_to_keep = {{ grafana_dashboard_history_versions_to_keep }}
 
 #################################### Users ####################################
 [users]
@@ -172,11 +219,49 @@ auto_assign_org = {{ grafana_users_auto_assign_org|default(true)|bool|lower }}
 # Default role new users will be automatically assigned (if disabled above is set to true)
 auto_assign_org_role = {{ grafana_users_auto_assign_org_role }}
 
-# Require email validation before sign up completes
-verify_email_enabled = {{ grafana_users_verify_email_enabled|default(false)|bool|lower }}
-
 # Background text for the user field on the login page
 login_hint = {{ grafana_users_login_hint }}
+password_hint = {{ grafana_users_password_hint }}
+
+# Default UI theme ("dark" or "light")
+default_theme = {{ grafana_users_default_theme }}
+
+# External user management, these options affect the organization users view
+external_manage_link_url = {{ grafana_users_external_manage_link_urk|default('') }}
+external_manage_link_name = {{ grafana_users_external_manage_link_name|default('') }}
+external_manage_info = {{ grafana_users_external_manage_info|default('') }}
+
+# Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
+viewers_can_edit = {{ grafana_users_viewers_can_edit|defaulf(false)|bool|lower }}
+
+# Editors can administrate dashboard, folders and teams they create
+editors_can_admin = {{ grafana_users_editors_can_admin|defaulf(false)|bool|lower }}
+
+[auth]
+# Login cookie name
+login_cookie_name = {{ grafana_users_auth_login_cookie_name }}
+
+# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days,
+login_maximum_inactive_lifetime_days = {{ grafana_users_auth_login_maximum_inactive_lifetime_days }}
+
+# The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
+login_maximum_lifetime_days = {{ grafana_users_auth_login_maximum_lifetime_days }}
+
+# How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
+token_rotation_interval_minutes = {{ grafana_users_auth_token_rotation_interval_minutes }}
+
+# Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
+disable_login_form = {{ grafana_users_auth_disable_login_form|defaulf(false)|bool|lower }}
+
+# Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
+disable_signout_menu = {{ grafana_users_auth_disable_signout_menu|defaulf(false)|bool|lower }}
+
+# URL to redirect the user to after sign out
+signout_redirect_url = {{ grafana_users_auth_signout_redirect_url|default('') }}
+
+# Set to true to attempt login with OAuth automatically, skipping the login screen.
+# This setting is ignored if multiple OAuth providers are configured.
+oauth_auto_login = {{ grafana_users_auth_oauth_auto_login|defaulf(false)|bool|lower }}
 
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
@@ -214,12 +299,46 @@ token_url = {{ grafana_auth_google_token_url }}
 api_url = {{ grafana_auth_google_api_url }}
 allowed_domains = {{ grafana_auth_google_allowed_domains }}
 
+#################################### Generic OAuth ##########################
+[auth.generic_oauth]
+enabled = {{ grafana_auth_oauth_enabled|default(false)|bool|lower }}
+name = {{ grafana_auth_oauth_name }}
+allow_sign_up = {{ grafana_auth_oauth_allow_sign_up|default(true)|bool|lower }}
+client_id = {{ grafana_auth_oauth_client_id }}
+client_secret = {{ grafana_auth_oauth_client_secret }}
+scopes = {{ grafana_auth_oauth_scopes }}
+auth_url = {{ grafana_auth_oauth_auth_url }}
+token_url = {{ grafana_auth_oauth_token_url }}
+api_url = {{ grafana_auth_oauth_api_url }}
+team_ids = {{ grafana_auth_oauth_team_ids|default('') }}
+allowed_organizations = {{ grafana_auth_oauth_allowed_organizations|default('') }}
+tls_skip_verify_insecure = {{ grafana_auth_oauth_tls_skip_verify_insecure|default(false)|bool|lower }}
+tls_client_cert = {{ grafana_auth_oauth_tls_client_cert|default('') }}
+tls_client_key = {{ grafana_auth_oauth_tls_client_key|default('') }}
+tls_client_ca = {{ grafana_auth_oauth_tls_client_ca|default('') }}
+
+; Set to true to enable sending client_id and client_secret via POST body instead of Basic authentication HTTP header
+; This might be required if the OAuth provider is not RFC6749 compliant, only supporting credentials passed via POST payload
+send_client_credentials_via_post = {{ grafana_auth_oauth_send_client_credentials_via_post|default(false)|bool|lower }}
+
+#################################### Grafana.com Auth ####################
+[auth.grafana_com]
+enabled = {{ grafana_auth_enabled|default(false)|bool|lower }}
+allow_sign_up = {{ grafana_auth_allow_sign_up|default(true)|bool|lower }}
+client_id = {{ grafana_auth_client_id }}
+client_secret = {{ grafana_auth_client_secret }}
+scopes = {{ grafana_auth_scopes }}
+allowed_organizations = {{ grafana_auth_allowed_organizations|default('') }}
+
 #################################### Auth Proxy ##########################
 [auth.proxy]
 enabled = {{ grafana_auth_proxy_enabled|default(false)|bool|lower }}
 header_name = {{ grafana_auth_proxy_header_name }}
 header_property = {{ grafana_auth_proxy_header_property }}
 auto_sign_up = {{ grafana_auth_proxy_auto_sign_up|default(true)|bool|lower }}
+ldap_sync_ttl = {{ grafana_auth_proxy_ldap_sync_ttl }}
+whitelist = {{ grafana_auth_proxy_whitelist }}
+headers = {{ grafana_auth_proxy_headers }}
 
 #################################### Basic Auth ##########################
 [auth.basic]
@@ -229,17 +348,22 @@ enabled = {{ grafana_auth_basic_enabled|default(true)|bool|lower }}
 [auth.ldap]
 enabled = {{ grafana_auth_ldap_enabled|default(false)|bool|lower }}
 config_file = {{ grafana_auth_ldap_config_file }}
+allow_sign_up = {{ grafana_auth_ldap_allow_sign_up|default('') }}
 
 #################################### SMTP / Emailing ##########################
 [smtp]
 enabled = {{ grafana_smtp_enabled|default(false)|bool|lower }}
 host = {{ grafana_smtp_host }}
 user = {{ grafana_smtp_user }}
+# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
 password = {{ grafana_smtp_password }}
 cert_file = {{ grafana_smtp_cert_file }}
 key_file = {{ grafana_smtp_key_file }}
 skip_verify = {{ grafana_smtp_skip_verify|default(false)|bool|lower }}
 from_address = {{ grafana_smtp_from_address }}
+from_name = {{ grafana_smtp_from_name }}
+# EHLO identity in SMTP dialog (defaults to instance_name)
+ehlo_identity = {{ grafana_smtp_ehlo_identity }}
 
 [emails]
 welcome_email_on_sign_up = {{ grafana_emails_welcome_email_on_sign_up|default(false)|bool|lower }}
@@ -250,19 +374,26 @@ welcome_email_on_sign_up = {{ grafana_emails_welcome_email_on_sign_up|default(fa
 # Use comma to separate multiple modes, e.g. "console, file"
 mode = {{ grafana_log_mode }}
 
-# Buffer length of channel, keep it as it is if you don't know what it is.
-buffer_len = {{ grafana_log_buffer_len|int }}
+# Either "debug", "info", "warn", "error", "critical", default is "info"
+level = {{ grafana_log_level|default('info') }}
 
-# Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Info"
-level = {{ grafana_log_level|default('Info') }}
+# optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
+filters = {{ grafana_log_filers }}
 
 # For "console" mode only
 [log.console]
 level = {{ grafana_log_console_level|default('') }}
 
+# log line format, valid options are text, console and json
+format = {{ grafana_log_console_format }}
+
 # For "file" mode only
 [log.file]
 level = {{ grafana_log_file_level|default('') }}
+
+# log line format, valid options are text, console and json
+format = {{ grafana_log_file_format }}
+
 # This enables automated log rotate(switch of following options), default is true
 log_rotate = {{ grafana_log_file_log_rotate|default(true)|bool|lower }}
 
@@ -278,48 +409,136 @@ daily_rotate = {{ grafana_log_file_daily_rotate|default(true)|bool|lower }}
 # Expired days of log file(delete after max days), default is 7
 max_days = {{ grafana_log_file_max_days|int }}
 
-#################################### AMPQ Event Publisher ##########################
-[event_publisher]
-enabled = {{ grafana_event_publisher_enabled|default(false)|bool|lower }}
-rabbitmq_url = {{ grafana_event_publisher_rabbitmq_url }}
-exchange = {{ grafana_event_publisher_exchange }}
+[log.syslog]
+level = {{ grafana_log_syslog_level|default('') }}
 
-#################################### Dashboard JSON files ##########################
-[dashboards.json]
-enabled = {{ grafana_dashboards_json_enabled|default(false)|bool|lower }}
-path = {{ grafana_dashboards_json_path }}
+# log line format, valid options are text, console and json
+format = {{ grafana_log_syslog_format }}
 
-#################################### Usage Quotas ##########################
-[quota]
-enabled = {{ grafana_quota_enabled|default(false)|bool|lower }}
+# Syslog network type and address. This can be udp, tcp, or unix. If left blank, the default unix endpoints will be used.
+;network =
+;address =
 
-#### set quotas to -1 to make unlimited. ####
-# limit number of users per Org.
-org_user = {{ grafana_quota_org_user }}
+# Syslog facility. user, daemon and local0 through local7 are valid.
+;facility =
 
-# limit number of dashboards per Org.
-org_dashboard = {{ grafana_quota_org_dashboard }}
+# Syslog tag. By default, the process' argv[0] is used.
+;tag =
 
-# limit number of data_sources per Org.
-org_data_source = {{ grafana_quota_org_data_source }}
+#################################### Alerting ############################
+[alerting]
+# Disable alerting engine & UI features
+;enabled = true
+# Makes it possible to turn off alert rule execution but alerting UI is visible
+;execute_alerts = true
 
-# limit number of api_keys per Org.
-org_api_key = {{ grafana_quota_org_api_key }}
+# Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
+;error_or_timeout = alerting
 
-# limit number of orgs a user can create.
-user_org = {{ grafana_quota_user_org }}
+# Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
+;nodata_or_nullvalues = no_data
 
-# Global limit of users.
-global_user = {{ grafana_quota_global_user }}
+# Alert notifications can include images, but rendering many images at the same time can overload the server
+# This limit will protect the server from render overloading and make sure notifications are sent out quickly
+;concurrent_render_limit = 5
 
-# global limit of orgs.
-global_org = {{ grafana_quota_global_org }}
 
-# global limit of dashboards
-global_dashboard = {{ grafana_quota_global_dashboard }}
+# Default setting for alert calculation timeout. Default value is 30
+;evaluation_timeout_seconds = 30
 
-# global limit of api_keys
-global_api_key = {{ grafana_quota_global_api_key }}
+# Default setting for alert notification timeout. Default value is 30
+;notification_timeout_seconds = 30
 
-# global limit on number of logged in users.
-global_session = {{ grafana_quota_global_session }}
+# Default setting for max attempts to sending alert notifications. Default value is 3
+;max_attempts = 3
+
+#################################### Explore #############################
+[explore]
+# Enable the Explore section
+;enabled = true
+
+#################################### Internal Grafana Metrics ##########################
+# Metrics available at HTTP API Url /metrics
+[metrics]
+# Disable / Enable internal metrics
+;enabled           = true
+
+# Publish interval
+;interval_seconds  = 10
+
+# Send internal metrics to Graphite
+[metrics.graphite]
+# Enable by setting the address setting (ex localhost:2003)
+;address =
+;prefix = prod.grafana.%(instance_name)s.
+
+#################################### Distributed tracing ############
+[tracing.jaeger]
+# Enable by setting the address sending traces to jaeger (ex localhost:6831)
+;address = localhost:6831
+# Tag that will always be included in when creating new spans. ex (tag1:value1,tag2:value2)
+;always_included_tag = tag1:value1
+# Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
+;sampler_type = const
+# jaeger samplerconfig param
+# for "const" sampler, 0 or 1 for always false/true respectively
+# for "probabilistic" sampler, a probability between 0 and 1
+# for "rateLimiting" sampler, the number of spans per second
+# for "remote" sampler, param is the same as for "probabilistic"
+# and indicates the initial sampling rate before the actual one
+# is received from the mothership
+;sampler_param = 1
+
+#################################### Grafana.com integration  ##########################
+# Url used to import dashboards directly from Grafana.com
+[grafana_com]
+;url = https://grafana.com
+
+#################################### External image storage ##########################
+[external_image_storage]
+# Used for uploading images to public servers so they can be included in slack/email messages.
+# you can choose between (s3, webdav, gcs, azure_blob, local)
+;provider =
+
+[external_image_storage.s3]
+;bucket =
+;region =
+;path =
+;access_key =
+;secret_key =
+
+[external_image_storage.webdav]
+;url =
+;public_url =
+;username =
+;password =
+
+[external_image_storage.gcs]
+;key_file =
+;bucket =
+;path =
+
+[external_image_storage.azure_blob]
+;account_name =
+;account_key =
+;container_name =
+
+[external_image_storage.local]
+# does not require any configuration
+
+[rendering]
+# Options to configure external image rendering server like https://github.com/grafana/grafana-image-renderer
+;server_url =
+;callback_url =
+
+[enterprise]
+# Path to a valid Grafana Enterprise license.jwt file
+;license_path =
+
+[panels]
+# If set to true Grafana will allow script tags in text panels. Not recommended as it enable XSS vulnerabilities.
+;disable_sanitize_html = false
+
+[plugins]
+;enable_alpha = false
+;app_tls_skip_verify_insecure = false

--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -232,10 +232,10 @@ external_manage_link_name = {{ grafana_users_external_manage_link_name|default('
 external_manage_info = {{ grafana_users_external_manage_info|default('') }}
 
 # Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
-viewers_can_edit = {{ grafana_users_viewers_can_edit|defaulf(false)|bool|lower }}
+viewers_can_edit = {{ grafana_users_viewers_can_edit|default(false)|bool|lower }}
 
 # Editors can administrate dashboard, folders and teams they create
-editors_can_admin = {{ grafana_users_editors_can_admin|defaulf(false)|bool|lower }}
+editors_can_admin = {{ grafana_users_editors_can_admin|default(false)|bool|lower }}
 
 [auth]
 # Login cookie name
@@ -251,17 +251,17 @@ login_maximum_lifetime_days = {{ grafana_users_auth_login_maximum_lifetime_days 
 token_rotation_interval_minutes = {{ grafana_users_auth_token_rotation_interval_minutes }}
 
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
-disable_login_form = {{ grafana_users_auth_disable_login_form|defaulf(false)|bool|lower }}
+disable_login_form = {{ grafana_users_auth_disable_login_form|default(false)|bool|lower }}
 
 # Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
-disable_signout_menu = {{ grafana_users_auth_disable_signout_menu|defaulf(false)|bool|lower }}
+disable_signout_menu = {{ grafana_users_auth_disable_signout_menu|default(false)|bool|lower }}
 
 # URL to redirect the user to after sign out
 signout_redirect_url = {{ grafana_users_auth_signout_redirect_url|default('') }}
 
 # Set to true to attempt login with OAuth automatically, skipping the login screen.
 # This setting is ignored if multiple OAuth providers are configured.
-oauth_auto_login = {{ grafana_users_auth_oauth_auto_login|defaulf(false)|bool|lower }}
+oauth_auto_login = {{ grafana_users_auth_oauth_auto_login|default(false)|bool|lower }}
 
 #################################### Anonymous Auth ##########################
 [auth.anonymous]

--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -416,70 +416,70 @@ level = {{ grafana_log_syslog_level|default('') }}
 format = {{ grafana_log_syslog_format }}
 
 # Syslog network type and address. This can be udp, tcp, or unix. If left blank, the default unix endpoints will be used.
-;network =
-;address =
+network = {{ grafana_log_syslog_network|default('') }}
+address = {{ grafana_log_syslog_address|default('') }}
 
 # Syslog facility. user, daemon and local0 through local7 are valid.
-;facility =
+facility = {{ grafana_log_syslog_facility|default('') }}
 
 # Syslog tag. By default, the process' argv[0] is used.
-;tag =
+tag = {{ grafana_log_syslog_tag|default('') }}
 
 #################################### Alerting ############################
 [alerting]
 # Disable alerting engine & UI features
-;enabled = true
+enabled = {{ grafana_alerting_enabled|default(true)|bool|lower }}
 # Makes it possible to turn off alert rule execution but alerting UI is visible
-;execute_alerts = true
+execute_alerts = {{ grafana_alerting_execute_alerts|default(true)|bool|lower }}
 
 # Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
-;error_or_timeout = alerting
+error_or_timeout = {{ grafana_alerting_error_or_timeout }}
 
 # Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
-;nodata_or_nullvalues = no_data
+nodata_or_nullvalues = {{ grafana_alerting_nodata_or_nullvalues }}
 
 # Alert notifications can include images, but rendering many images at the same time can overload the server
 # This limit will protect the server from render overloading and make sure notifications are sent out quickly
-;concurrent_render_limit = 5
+concurrent_render_limit = {{ grafana_alerting_concurrent_render_limit }}
 
 
 # Default setting for alert calculation timeout. Default value is 30
-;evaluation_timeout_seconds = 30
+evaluation_timeout_seconds = {{ grafana_alerting_evaluation_timeout_seconds }}
 
 # Default setting for alert notification timeout. Default value is 30
-;notification_timeout_seconds = 30
+notification_timeout_seconds = {{ grafana_alerting_notification_timeout_seconds }}
 
 # Default setting for max attempts to sending alert notifications. Default value is 3
-;max_attempts = 3
+max_attempts = {{ grafana_alerting_max_attempts }}
 
 #################################### Explore #############################
 [explore]
 # Enable the Explore section
-;enabled = true
+enabled = {{ grafana_explore_enabled|default(true)|bool|lower }}
 
 #################################### Internal Grafana Metrics ##########################
 # Metrics available at HTTP API Url /metrics
 [metrics]
 # Disable / Enable internal metrics
-;enabled           = true
+enabled           = {{ grafana_metrics_enabled|default(true)|bool|lower }}
 
 # Publish interval
-;interval_seconds  = 10
+interval_seconds  = {{ grafana_metrics_interval_seconds }}
 
 # Send internal metrics to Graphite
 [metrics.graphite]
 # Enable by setting the address setting (ex localhost:2003)
-;address =
-;prefix = prod.grafana.%(instance_name)s.
+address = {{ grafana_metrics_graphite_address|default('') }}
+prefix = {{ grafana_metrics_graphite_prefix }} 
 
 #################################### Distributed tracing ############
 [tracing.jaeger]
 # Enable by setting the address sending traces to jaeger (ex localhost:6831)
-;address = localhost:6831
+address = {{ grafana_tracing_jaeger_address }}
 # Tag that will always be included in when creating new spans. ex (tag1:value1,tag2:value2)
-;always_included_tag = tag1:value1
+always_included_tag = {{ grafana_tracing_jaeger_always_included_tag }}
 # Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
-;sampler_type = const
+sampler_type = {{ grafana_tracing_jaeger_sampler_type }}
 # jaeger samplerconfig param
 # for "const" sampler, 0 or 1 for always false/true respectively
 # for "probabilistic" sampler, a probability between 0 and 1
@@ -487,58 +487,58 @@ format = {{ grafana_log_syslog_format }}
 # for "remote" sampler, param is the same as for "probabilistic"
 # and indicates the initial sampling rate before the actual one
 # is received from the mothership
-;sampler_param = 1
+sampler_param = {{ grafana_tracing_jaeger_sampler_param }}
 
 #################################### Grafana.com integration  ##########################
 # Url used to import dashboards directly from Grafana.com
 [grafana_com]
-;url = https://grafana.com
+url = {{ grafana_dashboard_import_url }}
 
 #################################### External image storage ##########################
 [external_image_storage]
 # Used for uploading images to public servers so they can be included in slack/email messages.
 # you can choose between (s3, webdav, gcs, azure_blob, local)
-;provider =
+provider = {{ grafana_external_image_storage_provider|default('') }}
 
 [external_image_storage.s3]
-;bucket =
-;region =
-;path =
-;access_key =
-;secret_key =
+bucket = {{ grafana_external_image_storage_s3_bucket|default('') }}
+region = {{ grafana_external_image_storage_s3_region|default('') }}
+path = {{ grafana_external_image_storage_s3_path|default('') }}
+access_key = {{ grafana_external_image_storage_s3_access_key|default('') }}
+secret_key = {{ grafana_external_image_storage_s3_secret_key|default('') }}
 
 [external_image_storage.webdav]
-;url =
-;public_url =
-;username =
-;password =
+url = {{ grafana_external_image_storage_webdav_url|default('') }}
+public_url = {{ grafana_external_image_storage_webdav_public_url|default('') }}
+username = {{ grafana_external_image_storage_webdav_username|default('') }}
+password = {{ grafana_external_image_storage_webdav_password|default('') }}
 
 [external_image_storage.gcs]
-;key_file =
-;bucket =
-;path =
+key_file = {{ grafana_external_image_storage_gcs_key_file|default('') }}
+bucket = {{ grafana_external_image_storage_gcs_bucket|default('') }}
+path = {{ grafana_external_image_storage_gcs_path|default('') }}
 
 [external_image_storage.azure_blob]
-;account_name =
-;account_key =
-;container_name =
+account_name = {{ grafana_external_image_storage_azure_blob_account_name|default('') }}
+account_key = {{ grafana_external_image_storage_azure_blob_account_key|default('') }}
+container_name = {{ grafana_external_image_storage_azure_blob_container_name|default('') }}
 
 [external_image_storage.local]
 # does not require any configuration
 
 [rendering]
 # Options to configure external image rendering server like https://github.com/grafana/grafana-image-renderer
-;server_url =
-;callback_url =
+server_url = {{ grafana_external_image_storage_rendering_server_url|default('') }}
+callback_url = {{ grafana_external_image_storage_rendering_callback_url|default('') }}
 
 [enterprise]
 # Path to a valid Grafana Enterprise license.jwt file
-;license_path =
+license_path = {{ grafana_external_image_storage_enterprise_license_path|default('') }}
 
 [panels]
 # If set to true Grafana will allow script tags in text panels. Not recommended as it enable XSS vulnerabilities.
-;disable_sanitize_html = false
+disable_sanitize_html = {{ grafana_external_image_storage_panels_disable_sanitize_html|default(false)|bool|lower }}
 
 [plugins]
-;enable_alpha = false
-;app_tls_skip_verify_insecure = false
+enable_alpha = {{ grafana_external_image_storage_plugins_enable_alpha|default(false)|bool|lower }}
+app_tls_skip_verify_insecure = {{ grafana_external_image_storage_plugins_app_tls_skip_verify_insecure|default(false)|bool|lower }}

--- a/templates/ldap.toml.j2
+++ b/templates/ldap.toml.j2
@@ -1,5 +1,8 @@
-# Set to true to log user information returned from LDAP
-verbose_logging = {{ grafana_ldap_verbose_logging|default(false)|bool|lower }}
+# To troubleshoot and get more log info enable ldap debug logging in grafana.ini
+{% if grafana_ldap_log_enabled|default(false) %}
+[log]
+filters = ldap:debug
+{% endif %}
 
 [[servers]]
 # Ldap server host (specify multiple hosts space separated)
@@ -8,6 +11,8 @@ host = "{{ grafana_ldap_servers_host|default('127.0.0.1') }}"
 port = {{ grafana_ldap_servers_port|default('389') }}
 # Set to true if ldap server supports TLS
 use_ssl = {{ grafana_ldap_servers_use_ssl|default(false)|bool|lower }}
+# Set to true if connect ldap server with STARTTLS pattern (create connection in insecure, then upgrade to secure connection with TLS)
+start_tls = {{ grafana_ldap_servers_start_tls|default(false)|bool|lower }}
 # set to true if you want to skip ssl cert validation
 ssl_skip_verify = {{ grafana_ldap_servers_ssl_skip_verify|default(false)|bool|lower }}
 # set to the path to your root CA certificate or leave unset to use system defaults
@@ -15,10 +20,18 @@ ssl_skip_verify = {{ grafana_ldap_servers_ssl_skip_verify|default(false)|bool|lo
 {% if grafana_ldap_servers_root_ca_cert|default(false) %}
 root_ca_cert = "{{ grafana_ldap_servers_root_ca_cert }}"
 {% endif %}
+# Authentication against LDAP servers requiring client certificates
+{% if grafana_ldap_servers_client_cert|default(false) %}
+client_cert = "/path/to/client.crt"
+{% endif %}
+{% if grafana_ldap_servers_client_key|default(false) %}
+client_key = "/path/to/client.key"
+{% endif %}
 
 # Search user bind dn
 bind_dn = "{{ grafana_ldap_servers_bind_dn }}"
 # Search user bind password
+# If the password contains # or ; you have to wrap it with triple quotes. Ex """#password;"""
 bind_password = '{{ grafana_ldap_servers_bind_password }}'
 
 # User search filter, for example "(cn=%s)" or "(sAMAccountName=%s)" or "(uid=%s)"
@@ -27,44 +40,18 @@ search_filter = "{{ grafana_ldap_servers_search_filter }}"
 # An array of base dns to search through
 search_base_dns = ["{{ grafana_ldap_servers_search_base_dns|join('", "') }}"]
 
-# In POSIX LDAP schemas, without memberOf attribute a secondary query must be made for groups.
-# This is done by enabling group_search_filter below. You must also set member_of= "cn"
-# in [servers.attributes] below.
-
-# Users with nested/recursive group membership and an LDAP server that supports LDAP_MATCHING_RULE_IN_CHAIN
-# can set group_search_filter, group_search_filter_user_attribute, group_search_base_dns and member_of
-# below in such a way that the user's recursive group membership is considered.
-#
-# Nested Groups + Active Directory (AD) Example:
-#
-#   AD groups store the Distinguished Names (DNs) of members, so your filter must
-#   recursively search your groups for the authenticating user's DN. For example:
-#
-#     group_search_filter = "(member:1.2.840.113556.1.4.1941:=%s)"
-#     group_search_filter_user_attribute = "distinguishedName"
-#     group_search_base_dns = ["ou=groups,dc=grafana,dc=org"]
-#
-#     [servers.attributes]
-#     ...
-#     member_of = "distinguishedName"
-
-## Group search filter, to retrieve the groups of which the user is a member (only set if memberOf attribute is not available)
-# group_search_filter = "(&(objectClass=posixGroup)(memberUid=%s))"
+## For Posix or LDAP setups that does not support member_of attribute you can define the below settings
+### Please check grafana LDAP docs for examples
+## group_search_filter = "(&(objectClass=posixGroup)(memberUid=%s))"
 {% if grafana_ldap_servers_group_search_filter|default(false) %}
 group_search_filter = "{{ grafana_ldap_servers_group_search_filter }}"
 {% endif %}
 
-## Group search filter user attribute defines what user attribute gets substituted for %s in group_search_filter.
-## Defaults to the value of username in [server.attributes]
-## Valid options are any of your values in [servers.attributes]
-## If you are using nested groups you probably want to set this and member_of in
-## [servers.attributes] to "distinguishedName"
-# group_search_filter_user_attribute = "distinguishedName"
+# group_search_filter_user_attribute = "uid"
 {% if grafana_ldap_servers_group_search_filter_user_attribute|default(false) %}
 group_search_filter_user_attribute = "{{ grafana_ldap_servers_group_search_filter_user_attribute }}"
 {% endif %}
 
-## An array of the base DNs to search through for groups. Typically uses ou=groups
 # group_search_base_dns = ["ou=groups,dc=grafana,dc=org"]
 {% if grafana_ldap_servers_group_search_base_dns|default(false) %}
 group_search_base_dns = ["{{ grafana_ldap_servers_group_search_base_dns|join('", "') }}"]
@@ -78,6 +65,7 @@ username = "{{ grafana_ldap_servers_attributes_username }}"
 member_of = "{{ grafana_ldap_servers_attributes_member_of }}"
 email =  "{{ grafana_ldap_servers_attributes_email }}"
 
+# Map ldap groups to grafana org roles
 {% for group_mapping in grafana_ldap_servers_group_mappings %}
 [[servers.group_mappings]]
 group_dn = "{{ group_mapping.group_dn }}"


### PR DESCRIPTION
This PR manages all changes needed for Grafana 6.X : 
- grafana.ini template has been updated with all new settings and obsolete settings have been removed
- ldap.toml template has been updated as well 
- the yum and debian repo URL have been updated

This PR is not retro compatible and will no longer manages Grafana 5.X. 

I think we need to go forward and upgrading with this PR is really easy so there was no need for me to keep retro compat for the complexity it would have involved.

I have successfully upgraded my Grafana production instance with this PR.

I hope it can be merged soon.

Regards
