### PR TITLE
Remove deprecation warning

### DIFF
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -22,7 +22,7 @@
 #       "Failure talking to yum: failure: repodata/repomd.xml from grafana: [Errno 256] No more mirrors to try.\nhttps://packagecloud.io/grafana/stable/el/6/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml signature could not be verified for grafana"
 - name: Update repo cache for grafana repo
   command: yum -q makecache -y --disablerepo=* --enablerepo=grafana
-  when: import_key|changed
+  when: import_key is changed
   args:
     warn: False
 


### PR DESCRIPTION
The feature will be removed with next Ansible major release (2.9) so we need to be compliant to avoid breaking the role.